### PR TITLE
FS-1677: Pass through GITHUB_SHA in manifest

### DIFF
--- a/manifest.yaml
+++ b/manifest.yaml
@@ -23,6 +23,7 @@ applications:
     FLASK_ENV: test
     # Sentry DSN is OK to be public see: https://docs.sentry.io/product/sentry-basics/dsn-explainer/#dsn-utilization
     SENTRY_DSN: https://db2ea0ad22a44f4db6e81fe74d85fa8f@o1432034.ingest.sentry.io/4503903103352832
+    GITHUB_SHA: ((GITHUB_SHA))
   services:
     - funding-service-design-account-store-db
     - logit-ssl-drain


### PR DESCRIPTION
Pass through git sha, for use by Sentry release automation.