### PR TITLE
Fix: Update to enable dev to use Postgres DB

### DIFF
--- a/.github/workflows/manual-dev-deploy.yaml
+++ b/.github/workflows/manual-dev-deploy.yaml
@@ -13,7 +13,7 @@
         - name: Set up Python
           uses: actions/setup-python@v2
           with:
-            python-version: 3.10.1
+            python-version: 3.10.x
         - name: create python env
           run: python -m venv .venv
         - name: install dependencies

--- a/.github/workflows/manual-dev-deploy.yaml
+++ b/.github/workflows/manual-dev-deploy.yaml
@@ -28,4 +28,4 @@
             cf_space:    ${{secrets.CF_SPACE }}
             cf_username: ${{secrets.CF_USER}}
             cf_password: ${{secrets.CF_PASSWORD}}
-            command: push funding-service-design-account-store-dev
+            command: push funding-service-design-account-store-dev --var GITHUB_SHA="${{ github.sha }}"

--- a/config/envs/dev.py
+++ b/config/envs/dev.py
@@ -1,7 +1,5 @@
 """Flask Dev Pipeline Environment Configuration."""
 import logging
-from os import environ
-from os import path
 
 from config.envs.default import DefaultConfig
 from fsd_utils import configclass
@@ -15,7 +13,4 @@ class DevConfig(DefaultConfig):
 
     # Logging
     FSD_LOG_LEVEL = logging.INFO
-    SQLALCHEMY_DATABASE_URI = environ.get(
-        "DATABASE_URL"
-    ) or "sqlite:///" + path.join(DefaultConfig.FLASK_ROOT, "sqlite.db")
     SQLALCHEMY_TRACK_MODIFICATIONS = False

--- a/config/envs/production.py
+++ b/config/envs/production.py
@@ -3,56 +3,6 @@ from config.envs.default import DefaultConfig as Config
 from fsd_utils import configclass
 
 
-# TODO : Uncomment the following if using a GovPaaS VcapServices
-#  redis instance for session management.
-#  The VcapServices helper class has methods to parse the chosen
-#  redis instance url from the Cloud Foundry VcapServices env dictionary
-# import redis
-# import json
-# from os import environ
-# from dataclasses import dataclass
-#
-#
-# @dataclass
-# class VcapServices(object):
-#
-#     services: dict
-#
-#     @staticmethod
-#     def from_env_json(json_string: str):
-#         json_dict = dict(json.loads(json_string))
-#         vcap_services = VcapServices(services=json_dict)
-#         return vcap_services
-#
-#     def get_service_by_name(self, group_key: str, name: str) -> dict:
-#         service_group = self.services.get(group_key)
-#         if service_group:
-#             for service in service_group:
-#                 if service.get("name") == name:
-#                     return service
-#             raise Exception(f"Service name '{name}' not found")
-#         raise Exception(f"Service group '{group_key}' not found")
-#
-#     def get_service_credentials_value(
-#         self, group_key: str, name: str, key: str
-#     ):
-#         service = self.get_service_by_name(group_key, name)
-#         return service.get("credentials").get(key)
-
-
 @configclass
 class ProductionConfig(Config):
-
-    # TODO: Uncomment the following if using a GovPaaS VcapServices
-    #  redis instance for session management
-    # # GOV.UK PaaS
-    # VCAP_SERVICES = VcapServices.from_env_json(environ.get("VCAP_SERVICES"))
-    #
-    # # Redis
-    # REDIS_INSTANCE_NAME = "funding-service-TEMPLATE-production"
-    # REDIS_INSTANCE_URI = VCAP_SERVICES.get_service_credentials_value(
-    #     "redis", REDIS_INSTANCE_NAME, "uri"
-    # )
-    # REDIS_SESSIONS_URL = REDIS_INSTANCE_URI + "/0"
-    # SESSION_REDIS = redis.from_url(REDIS_SESSIONS_URL)
     pass

--- a/manifest.yaml
+++ b/manifest.yaml
@@ -26,7 +26,7 @@ applications:
     SENTRY_DSN: https://db2ea0ad22a44f4db6e81fe74d85fa8f@o1432034.ingest.sentry.io/4503903103352832
     GITHUB_SHA: ((GITHUB_SHA))
   services:
-    - funding-service-design-account-store-db
+    - funding-service-design-account-store-test-db
     - logit-ssl-drain
   health-check-http-endpoint: /healthcheck
   health-check-type: http

--- a/manifest.yaml
+++ b/manifest.yaml
@@ -3,13 +3,14 @@ applications:
   memory: 1024M
   buildpacks:
   - https://github.com/cloudfoundry/python-buildpack.git
-  command: gunicorn wsgi:app -c run/gunicorn/devtest.py
+  command: scripts/run_migrations_paas.py && gunicorn wsgi:app -c run/gunicorn/devtest.py
   env:
     FLASK_ENV: dev
     FLASK_DEBUG: 1
     # Sentry DSN is OK to be public see: https://docs.sentry.io/product/sentry-basics/dsn-explainer/#dsn-utilization
     SENTRY_DSN: https://db2ea0ad22a44f4db6e81fe74d85fa8f@o1432034.ingest.sentry.io/4503903103352832
   services:
+    - funding-service-design-account-store-dev-db
     - logit-ssl-drain
   health-check-http-endpoint: /healthcheck
   health-check-type: http


### PR DESCRIPTION
### Update to enable dev to use Postgres DB

- Manifest updated to run scripts/run_migrations_pass.py on dev deploy and add funding-service-design-account-store-dev-db as a service
- Manifest updated to rename funding-service-design-account-store-db too funding-service-design-account-store-test-db
- Removed commented sections of un-required code from production config