### PR TITLE
FS-2003-update-bulk-accounts-functionality

### DIFF
--- a/core/account.py
+++ b/core/account.py
@@ -59,7 +59,7 @@ def get_account(
 
 
 def get_bulk_accounts(
-    account_id: list,
+    account_ids: list,
 ) -> Dict:
     """
     Get multiple accounts corresponding to the given account ids
@@ -68,26 +68,25 @@ def get_bulk_accounts(
     :return:
         Nested dict of account_id: {account object}
     """
-    if not account_id:
+    if not account_ids:
         return {
             "error": (
                 "Bad request: please provide at least 1 account_id "
             )
         }, 400
 
-    stmnt = select(Account)
-    stmnt = stmnt.filter(Account.id.in_(account_id))
-
+    accounts_metadatas = []
     try:
-        result = db.session.scalars(stmnt)
-        account_schema = AccountSchema()
+        for account_id in account_ids:
+            stmnt = select(Account).where(Account.id == account_id)
 
-        accounts_metadatas = { 
-            str(account_row.id) : account_schema.dump(account_row) 
-            for account_row in result    
-        }
+            result = db.session.scalar(stmnt)
+            account_schema = AccountSchema()
 
+            accounts_metadata = {str(result.id) : account_schema.dump(result)}
+            accounts_metadatas.append(accounts_metadata)
         return accounts_metadatas, 200
+
     except sqlalchemy.exc.NoResultFound:
         return {"error": "No matching account found"}, 404
 

--- a/openapi/api.yml
+++ b/openapi/api.yml
@@ -124,9 +124,9 @@ paths:
         404:
           description: "The requested accounts do not exist."
       parameters:
-        - name: account_id
+        - name: account_ids
           in: query
-          description: "The account id used for the account record lookup"
+          description: "The account ids used for the account record lookup"
           required: false
           schema:
             type: array
@@ -138,7 +138,7 @@ components:
     BulkAccount:
       type: object
       properties:
-        account_id:
+        account_ids:
           type: object
           properties:
             account_id:

--- a/tests/test_accounts.py
+++ b/tests/test_accounts.py
@@ -196,7 +196,7 @@ class TestAccountsGet:
         THEN matching account records are returned with the correct params
         """
         account_ids = []
-        expected_response_data = {}
+        expected_response_data = []
 
         # Create a valid record
         records_to_create = [
@@ -222,7 +222,7 @@ class TestAccountsGet:
             assert response.status_code == 201
             account_ids.append(response.json["account_id"])
 
-            expected_response_data.update({
+            expected_response_data.append({
                 response.json["account_id"]: {
                     "account_id": response.json["account_id"],
                     "azure_ad_subject_id": response.json["azure_ad_subject_id"],
@@ -231,9 +231,9 @@ class TestAccountsGet:
                     "roles": []
                 }
             })
-            
+        
         # Check expected response with account_id query arg
-        account_id_arg = "account_id="
+        account_id_arg = "account_ids="
         account_id_arg_url = "/bulk-accounts?" + account_id_arg
 
         count = 0
@@ -241,7 +241,7 @@ class TestAccountsGet:
             if count < 1:
                 account_id_arg_url += id
                 count += 1
-            else: account_id_arg_url += "&account_id=" + id
+            else: account_id_arg_url += "&account_ids=" + id
 
         expected_data_within_response(
             flask_test_client, account_id_arg_url, expected_response_data, 200


### PR DESCRIPTION
Updating the bulk accounts endpoint to return metadata by order of account_id provided and return metadata even if multiple instances of the same account_id is given, this is to preserve order and occurrence of who made a score/ comment when using this functionality in assessment to display user info. 