### PR TITLE
FS-2172: add workflow to bump tag

### DIFF
--- a/.github/workflows/bump-tag.yml
+++ b/.github/workflows/bump-tag.yml
@@ -1,0 +1,11 @@
+name: Bump tag
+on:
+  pull_request:
+    types:
+      - closed
+    branches:
+      - main
+jobs:
+  bump-tag:
+    if: ${{ github.actor != 'dependabot[bot]' }}
+    uses: communitiesuk/funding-service-design-workflows/.github/workflows/bump-tag.yml@main   


### PR DESCRIPTION
Use shared workflow to bump tag added in https://github.com/communitiesuk/funding-service-design-workflows/pull/33 Roll-out plan is to test with this merging this PR and roll-out more widely if successful