### PR TITLE
FS-3075 split aws pre deploy

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -11,17 +11,22 @@ on:
         - test
         - uat
       copilot:
-        description: Whether to deploy
+        description: Whether to deploy to AWS?
         type: boolean
         required: false
         default: false
+      deploy_to_dev:
+        required: false
+        default: false
+        type: boolean
+        description: Deploy to CloudFoundry dev?
   push:
     paths-ignore:
       - '**/README.md'
 
 jobs:
   test_and_deploy:
-    if: ${{ github.actor != 'dependabot[bot]' }}
+    if: ${{ github.actor != 'dependabot[bot]' }} && ${{ !github.event.inputs.copilot }}
     uses: communitiesuk/funding-design-service-workflows/.github/workflows/deploy.yml@main
     with:
       app_name: ${{ github.event.repository.name }}
@@ -46,9 +51,18 @@ jobs:
       version_to_build: $(echo "${{ github.ref }}" | sed -e 's,.*/\(.*\),\1,')
       owner: ${{ github.repository_owner }}
       application: funding-service-design-account-store
-  copilot_build:
+  pre_deploy_tests:
     if: ${{ github.event.inputs.copilot }}
-    needs: [test_and_deploy]
+    secrets:
+      E2E_PAT: ${{secrets.E2E_PAT}}
+    uses: communitiesuk/funding-design-service-workflows/.github/workflows/pre-deploy.yml@main
+    with:
+      db_name: fsd_account_store_test
+      postgres_unit_testing: true
+  copilot_build:
+    if: ${{ !always() }}
+    #if: ${{ github.event.inputs.copilot }}
+    needs: [pre_deploy_tests, paketo_build]
     concurrency: deploy-${{ inputs.environment || 'test' }}
     permissions:
       id-token: write # This is required for requesting the JWT

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -60,8 +60,7 @@ jobs:
       db_name: fsd_account_store_test
       postgres_unit_testing: true
   copilot_build:
-    if: ${{ !always() }}
-    #if: ${{ github.event.inputs.copilot }}
+    if: ${{ github.event.inputs.copilot }}
     needs: [pre_deploy_tests, paketo_build]
     concurrency: deploy-${{ inputs.environment || 'test' }}
     permissions:

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -26,7 +26,7 @@ on:
 
 jobs:
   test_and_deploy:
-    if: ${{ github.actor != 'dependabot[bot]' }} && ${{ !github.event.inputs.copilot }}
+    if: ${{ github.actor != 'dependabot[bot]' && !github.event.inputs.copilot }}
     uses: communitiesuk/funding-design-service-workflows/.github/workflows/deploy.yml@main
     with:
       app_name: ${{ github.event.repository.name }}


### PR DESCRIPTION
https://dluhcdigital.atlassian.net/browse/FS-3075

### Change description
Allow pre-deploy scripts to run separately for AWS deployments

- [X] Unit tests and other appropriate tests added or updated
- [n/a] README and other documentation has been updated / added (if needed)
- [X] Commit messages are meaningful and follow good commit message guidelines (e.g. "FS-XXXX: Add margin to nav items preventing overlapping of logo")


### How to test
Tested using deploy to AWS with an ${{ !always() }} flag on.

### Screenshots of UI changes (if applicable)
