### PR TITLE
FS-3441 added yelp hook for secrets

### DIFF
--- a/.flaskenv
+++ b/.flaskenv
@@ -2,4 +2,3 @@ FLASK_APP=app.py
 FLASK_ENV=development
 FLASK_RUN_PORT=5000
 FLASK_RUN_HOST=localhost
-DATABASE_URL=postgresql://postgres:postgres@127.0.0.1:5432/fsd_account_store_dev

--- a/.github/workflows/manual-dev-deploy.yaml
+++ b/.github/workflows/manual-dev-deploy.yaml
@@ -39,10 +39,10 @@
         perf_test_target_url_application_store: https://funding-service-design-application-store-dev.london.cloudapps.digital
         perf_test_target_url_fund_store: https://funding-service-design-fund-store-dev.london.cloudapps.digital
         perf_test_target_url_assessment_store: https://funding-service-design-assessment-store-dev.london.cloudapps.digital
-        e2e_tests_target_url_frontend: https://fsd:fsd@frontend.dev.gids.dev
-        e2e_tests_target_url_authenticator: https://fsd:fsd@authenticator2.dev.gids.dev
-        e2e_tests_target_url_form_runner: https://fsd:fsd@forms.dev.gids.dev
-        e2e_tests_target_url_assessment: https://fsd:fsd@assessment.dev.gids.dev
+        e2e_tests_target_url_frontend: https://fsd:fsd@frontend.dev.gids.dev  # pragma: allowlist secret
+        e2e_tests_target_url_authenticator: https://fsd:fsd@authenticator2.dev.gids.dev  # pragma: allowlist secret
+        e2e_tests_target_url_form_runner: https://fsd:fsd@forms.dev.gids.dev  # pragma: allowlist secret
+        e2e_tests_target_url_assessment: https://fsd:fsd@assessment.dev.gids.dev  # pragma: allowlist secret
         run_performance_tests: true
         run_e2e_tests: false
       secrets:

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -24,3 +24,10 @@ repos:
       - id: reorder-python-imports
         name: Reorder Python imports (src, tests)
         args: ["--application-directories", "src"]
+- repo: https://github.com/Yelp/detect-secrets
+  rev: v1.4.0
+  hooks:
+  -   id: detect-secrets
+      args: ['--disable-plugin', 'HexHighEntropyString',
+        '--disable-plugin', 'Base64HighEntropyString']
+      exclude: .env.development

--- a/README.md
+++ b/README.md
@@ -71,8 +71,9 @@ You can then either manually create a database called `fsd_account_store_dev` or
 
 Once you have created the database you need to set the `DATABASE_URL` environment variable so the application knows where to find it.
 
-This url has been set in the `.flaskenv` file in the root as
+This url can be set in the `.flaskenv` file in the root as
 
+    # pragma: allowlist nextline secret
     DATABASE_URL==postgresql://postgres:postgres@127.0.0.1:5432/fsd_account_store_dev
 
 ...so if you are running locally on a development machine and you have used the `invoke bootstrap_dev_db` script above to create the database, it should just connect automatically.

--- a/config/envs/dev.py
+++ b/config/envs/dev.py
@@ -8,7 +8,7 @@ from fsd_utils import configclass
 @configclass
 class DevConfig(DefaultConfig):
     #  Application Config
-    SECRET_KEY = "dev"
+    SECRET_KEY = "dev"  # pragma: allowlist secret
     SESSION_COOKIE_NAME = "session_cookie"
 
     # Logging

--- a/config/envs/development.py
+++ b/config/envs/development.py
@@ -8,7 +8,7 @@ from fsd_utils import configclass
 @configclass
 class DevelopmentConfig(Config):
     #  Application Config
-    SECRET_KEY = "dev"
+    SECRET_KEY = "dev"  # pragma: allowlist secret
     SESSION_COOKIE_NAME = "session_cookie"
     FLASK_ENV = "development"
 

--- a/config/envs/unit_test.py
+++ b/config/envs/unit_test.py
@@ -8,7 +8,7 @@ from fsd_utils import configclass
 @configclass
 class UnitTestConfig(Config):
     #  Application Config
-    SECRET_KEY = "dev"
+    SECRET_KEY = "dev"  # pragma: allowlist secret
     SESSION_COOKIE_NAME = "session_cookie"
 
     # Logging

--- a/copilot/environments/addons/funding-service-magic-links.yml
+++ b/copilot/environments/addons/funding-service-magic-links.yml
@@ -88,6 +88,6 @@ Outputs:
     Value:
       !Sub
       - "rediss://:${PASSWORD}@${HOSTNAME}:${PORT}"
-      - PASSWORD: !Join [ "",  [ '{{resolve:secretsmanager:', !Ref 'RedisSecret', ":SecretString:password}}" ]]
+      - PASSWORD: !Join [ "",  [ '{{resolve:secretsmanager:', !Ref 'RedisSecret', ":SecretString:password}}" ]]  # pragma: allowlist secret
         HOSTNAME: !GetAtt 'Redis.RedisEndpoint.Address'
         PORT: !GetAtt 'Redis.RedisEndpoint.Port'

--- a/copilot/fsd-account-store/addons/fsd-account-store-cluster.yml
+++ b/copilot/fsd-account-store/addons/fsd-account-store-cluster.yml
@@ -85,9 +85,9 @@ Resources:
     Type: 'AWS::RDS::DBCluster'
     Properties:
       MasterUsername:
-        !Join [ "",  [ '{{resolve:secretsmanager:', !Ref fsdaccountstoreclusterAuroraSecret, ":SecretString:username}}" ]]
+        !Join [ "",  [ '{{resolve:secretsmanager:', !Ref fsdaccountstoreclusterAuroraSecret, ":SecretString:username}}" ]]  # pragma: allowlist secret
       MasterUserPassword:
-        !Join [ "",  [ '{{resolve:secretsmanager:', !Ref fsdaccountstoreclusterAuroraSecret, ":SecretString:password}}" ]]
+        !Join [ "",  [ '{{resolve:secretsmanager:', !Ref fsdaccountstoreclusterAuroraSecret, ":SecretString:password}}" ]]  # pragma: allowlist secret
       DatabaseName: !Ref fsdaccountstoreclusterDBName
       Engine: 'aurora-postgresql'
       EngineVersion: '14.4'
@@ -126,11 +126,11 @@ Outputs:
     Value:
       !Sub
       - "postgres://${USERNAME}:${PASSWORD}@${HOSTNAME}:${PORT}/${DBNAME}"
-      - USERNAME: !Join [ "",  [ '{{resolve:secretsmanager:', !Ref fsdaccountstoreclusterAuroraSecret, ":SecretString:username}}" ]]
-        PASSWORD: !Join [ "",  [ '{{resolve:secretsmanager:', !Ref fsdaccountstoreclusterAuroraSecret, ":SecretString:password}}" ]]
-        HOSTNAME: !Join [ "",  [ '{{resolve:secretsmanager:', !Ref fsdaccountstoreclusterAuroraSecret, ":SecretString:host}}" ]]
-        PORT: !Join [ "",  [ '{{resolve:secretsmanager:', !Ref fsdaccountstoreclusterAuroraSecret, ":SecretString:port}}" ]]
-        DBNAME: !Join [ "",  [ '{{resolve:secretsmanager:', !Ref fsdaccountstoreclusterAuroraSecret, ":SecretString:dbname}}" ]]
+      - USERNAME: !Join [ "",  [ '{{resolve:secretsmanager:', !Ref fsdaccountstoreclusterAuroraSecret, ":SecretString:username}}" ]]  # pragma: allowlist secret
+        PASSWORD: !Join [ "",  [ '{{resolve:secretsmanager:', !Ref fsdaccountstoreclusterAuroraSecret, ":SecretString:password}}" ]]  # pragma: allowlist secret
+        HOSTNAME: !Join [ "",  [ '{{resolve:secretsmanager:', !Ref fsdaccountstoreclusterAuroraSecret, ":SecretString:host}}" ]]  # pragma: allowlist secret
+        PORT: !Join [ "",  [ '{{resolve:secretsmanager:', !Ref fsdaccountstoreclusterAuroraSecret, ":SecretString:port}}" ]]  # pragma: allowlist secret
+        DBNAME: !Join [ "",  [ '{{resolve:secretsmanager:', !Ref fsdaccountstoreclusterAuroraSecret, ":SecretString:dbname}}" ]]  # pragma: allowlist secret
 
   fsdaccountstoreclusterSecret: # injected as FSDACCOUNTSTORECLUSTER_SECRET environment variable by Copilot.
     Description: "The JSON secret that holds the database username and password. Fields are 'host', 'port', 'dbname', 'username', 'password', 'dbClusterIdentifier' and 'engine'"

--- a/pytest.ini
+++ b/pytest.ini
@@ -2,5 +2,6 @@
 env =
     FLASK_ENV=unit_test
     FLASK_DEBUG=1
+    # pragma: allowlist nextline secret
     D:DATABASE_URL=postgresql://postgres:postgres@127.0.0.1:5432/fsd_account_store
     GITHUB_SHA=123123

--- a/scripts/remove_duplicate_accounts.py
+++ b/scripts/remove_duplicate_accounts.py
@@ -33,15 +33,15 @@ import psycopg2
 
 ACCOUNT_STORE_DB = os.getenv(
     "ACCOUNT_STORE_DB_URL",
-    "postgresql://postgres:password@localhost:5432/account_store",
+    "postgresql://postgres:password@localhost:5432/account_store",  # pragma: allowlist secret
 )
 APPLICATION_STORE_DB = os.getenv(
     "APPLICATION_STORE_DB_URL",
-    "postgresql://postgres:password@localhost:5432/application_store",
+    "postgresql://postgres:password@localhost:5432/application_store",  # pragma: allowlist secret
 )
 ASSESSMENT_STORE_DB = os.getenv(
     "ASSESSMENT_STORE_DB_URL",
-    "postgresql://postgres:password@localhost:5432/assessment_store",
+    "postgresql://postgres:password@localhost:5432/assessment_store",  # pragma: allowlist secret
 )
 
 


### PR DESCRIPTION
https://dluhcdigital.atlassian.net/browse/FS-3441

### Description
- Added pre-commit 'Yelp/detect-secrets' to prevent committing of secrets to code base
- Ignore false positives by marking them with `pragma: allowlist secret`
- disabled the plugins `HexHighEntropyString` & `Base64HighEntropyString `which tend to detect lot of false positives

### How to test
- Add a secret/API key/password to any of the file type
  For eg. `API_KEY= "125fdfbdjhbj5989"`
- stage the file & commit it.
- Notice the commit is failed with errors. 