### PR TITLE
FS-3457 - Add Bastion's SG into the ingress into Addon RDS

### DIFF
--- a/copilot/fsd-account-store/addons/fsd-account-store-cluster.yml
+++ b/copilot/fsd-account-store/addons/fsd-account-store-cluster.yml
@@ -20,6 +20,9 @@ Mappings:
     All:
       "DBMinCapacity": 0.5 # AllowedValues: from 0.5 through 128
       "DBMaxCapacity": 8   # AllowedValues: from 0.5 through 128
+  BastionMap:
+    test:
+      "SecurityGroup": "sg-0cf75a004dbade7b8"
 
 Resources:
   fsdaccountstoreclusterDBSubnetGroup:
@@ -52,6 +55,11 @@ Resources:
           IpProtocol: tcp
           Description: !Sub 'From the Aurora Security Group of the workload ${Name}.'
           SourceSecurityGroupId: !Ref fsdaccountstoreclusterSecurityGroup
+        - ToPort: 5432
+          FromPort: 5432
+          IpProtocol: tcp
+          Description: !Sub 'From the Bastion Security Group.'
+          SourceSecurityGroupId: !FindInMap [BastionMap, !Ref Env, 'SecurityGroup']
       VpcId:
         Fn::ImportValue:
           !Sub '${App}-${Env}-VpcId'


### PR DESCRIPTION
https://dluhcdigital.atlassian.net/browse/FS-3457

### Change description
Add in Bastion's security group into the fsd-account-store DB's inbound rules.
Tested by using the aws ssm connection through bastion and being able to connect into the postgres DB.

- [n/a] Unit tests and other appropriate tests added or updated
- [n/a] README and other documentation has been updated / added (if needed)
- [X] Commit messages are meaningful and follow good commit message guidelines (e.g. "FS-XXXX: Add margin to nav items preventing overlapping of logo")


### How to test
_If manual testing is needed, give suggested testing steps_


### Screenshots of UI changes (if applicable)
