### PR TITLE
remove check against VALID roles configuration

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,9 +2,6 @@ FROM python:3.10-bullseye
 
 WORKDIR /app
 COPY requirements-dev.txt requirements-dev.txt
-# Install system-level dependencies
-RUN apt-get update && apt-get install -y libpq-dev
-
 RUN pip --no-cache-dir install --ignore-installed distlib -r requirements-dev.txt
 RUN pip install gunicorn
 COPY . .

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,6 +2,9 @@ FROM python:3.10-bullseye
 
 WORKDIR /app
 COPY requirements-dev.txt requirements-dev.txt
+# Install system-level dependencies
+RUN apt-get update && apt-get install -y libpq-dev
+
 RUN pip --no-cache-dir install --ignore-installed distlib -r requirements-dev.txt
 RUN pip install gunicorn
 COPY . .

--- a/core/account.py
+++ b/core/account.py
@@ -9,6 +9,7 @@ from db import db
 from db.models.account import Account
 from db.models.role import Role
 from db.schemas.account import AccountSchema
+from flask import current_app
 from flask import request
 from sqlalchemy import delete
 from sqlalchemy import or_

--- a/core/account.py
+++ b/core/account.py
@@ -9,7 +9,6 @@ from db import db
 from db.models.account import Account
 from db.models.role import Role
 from db.schemas.account import AccountSchema
-from flask import current_app
 from flask import request
 from sqlalchemy import delete
 from sqlalchemy import or_

--- a/tests/test_accounts.py
+++ b/tests/test_accounts.py
@@ -301,7 +301,7 @@ class TestAccountsPut:
         """
 
         account_id = str(test_user_to_update["account_id"])
-        new_roles = ["LEAD_ASSESSOR"]
+        new_roles = ["COF_COMMENTER"]
         params = {
             "roles": new_roles,
             "azure_ad_subject_id": "subject_id_x",
@@ -312,9 +312,9 @@ class TestAccountsPut:
         assert response.status_code == 201
 
         assert response.json["account_id"] == account_id
-        assert response.json["roles"] == ["COF_LEAD_ASSESSOR"]
+        assert response.json["roles"] == ["COF_COMMENTER"]
 
-    def test_update_role_with_non_existent_role_fails(
+    def test_update_role_with_non_existent_role_allows(
         self, flask_test_client, clear_test_data, seed_test_data
     ):
         """
@@ -322,15 +322,18 @@ class TestAccountsPut:
         WHEN we PUT to the /accounts/{account_id} endpoint
         WITH a json payload of
         {
-            "roles":"BAD_ROLE",
+            "roles":"NON_EXISTENT_ROLE",
             "azure_ad_subject_id": <existing_subject_id>,
         }
-        THEN tan error is returned
+        THEN it is allowed
+
+        Each application should check roles for an account
+        before allowing access.
 
         """
 
         account_id = str(test_user_to_update["account_id"])
-        new_roles = ["BAD_ROLE"]
+        new_roles = ["NON_EXISTENT_ROLE"]
         params = {
             "roles": new_roles,
             "azure_ad_subject_id": "subject_id_x",
@@ -339,5 +342,4 @@ class TestAccountsPut:
 
         response = flask_test_client.put(url, json=params)
 
-        assert response.status_code == 401
-        assert "Role 'BAD_ROLE' is not valid" in response.json.get("error")
+        assert response.status_code == 201


### PR DESCRIPTION
we no longer need a check against valid roles as the deprecated roles are no longer being used. Furthermore if a role is not valid it serves no purpose as our applications check roles validity before allowing access.