### PR TITLE
Added API endpoint to retrieve users for fund

### DIFF
--- a/openapi/api.yml
+++ b/openapi/api.yml
@@ -105,6 +105,50 @@ paths:
           schema:
             type: string
             format: path
+  /accounts/fund/{fund_short_name}:
+    get:
+      tags:
+        - accounts
+      summary: Return the users assigned roles related to the fund
+      description: "Given a fund, return the users assigned with a role. Filterable by assessors, commenters and round"
+      operationId: core.account.get_accounts_for_fund
+      parameters:
+        - name: fund_short_name
+          in: path
+          schema:
+            type: string
+          required: true
+        - name: include_assessors
+          in: query
+          description: "Results will include assessors"
+          required: false
+          schema:
+            type: string
+            default: "true"
+        - name: include_commenters
+          in: query
+          description: "Results will include commenters"
+          required: false
+          schema:
+            type: string
+            default: "true"
+        - name: round_short_name
+          in: query
+          description: "Results will include only roles for that round"
+          required: false
+          schema:
+            type: string
+            example: "R1"
+      responses:
+        200:
+          description: One or more account exist and are associated with the fund and round
+          content:
+            application/json:
+              schema:
+                type: array
+                $ref: '#/components/schemas/account'
+        404:
+          description: "No associated accounts found."
   /bulk-accounts:
     get:
       tags:

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -80,3 +80,18 @@ def seed_test_data(request, app, clear_test_data, _db):
     for user in users_to_create:
         create_user_with_roles(user, _db)
     yield users_to_create
+
+
+@pytest.fixture(scope="function")
+def seed_test_data_fn(request, app, clear_test_data, _db):
+    marker = request.node.get_closest_marker("user_config")
+    if not marker:
+        users_to_create = [test_user_1, test_user_2, test_user_to_update]
+    else:
+        users_to_create = marker.args[0]
+    for user in users_to_create:
+        create_user_with_roles(user, _db)
+    yield users_to_create
+    Role.query.delete()
+    Account.query.delete()
+    _db.session.commit()


### PR DESCRIPTION
### Change description
Added an API endpoint to be able to retrieve users that have roles (assessors, commenters) related to a fund. 

- [x] Unit tests and other appropriate tests added or updated
- [ ] README and other documentation has been updated / added (if needed)
- [x] Commit messages are meaningful and follow good commit message guidelines (e.g. "FS-XXXX: Add margin to nav items preventing overlapping of logo")


### How to test
N/A


### Screenshots of UI changes (if applicable)
N/A