### PR TITLE
Make azure_ad_subject_id optional

### DIFF
--- a/core/account.py
+++ b/core/account.py
@@ -108,11 +108,8 @@ def put_account(account_id: str) -> Tuple[dict, int]:
         roles = request.json["roles"]
     except KeyError:
         return {"error": "roles are required"}, 401
-    try:
-        azure_ad_subject_id = request.json["azure_ad_subject_id"]
-    except KeyError:
-        return {"error": "azure_ad_subject_id is required"}, 401
 
+    azure_ad_subject_id = request.json.get("azure_ad_subject_id", None)
     full_name = request.json.get("full_name")
     email = request.json.get("email_address", "").lower()
 
@@ -122,10 +119,7 @@ def put_account(account_id: str) -> Tuple[dict, int]:
             db.session.query(Account)
             .filter(
                 Account.id == account_id,
-                or_(
-                    Account.azure_ad_subject_id == azure_ad_subject_id,
-                    Account.azure_ad_subject_id.is_(None),
-                ),
+                Account.azure_ad_subject_id == azure_ad_subject_id,
             )
             .one()
         )

--- a/core/account.py
+++ b/core/account.py
@@ -2,11 +2,14 @@
 Contains the functions directly used by the openapi spec.
 """
 
-from typing import Dict, Tuple
+from typing import Dict
+from typing import Tuple
 
 import sqlalchemy
 from flask import request
-from sqlalchemy import delete, or_, select
+from sqlalchemy import delete
+from sqlalchemy import or_
+from sqlalchemy import select
 from sqlalchemy.orm import selectinload
 
 from db import db

--- a/core/account.py
+++ b/core/account.py
@@ -2,14 +2,11 @@
 Contains the functions directly used by the openapi spec.
 """
 
-from typing import Dict
-from typing import Tuple
+from typing import Dict, Tuple
 
 import sqlalchemy
 from flask import request
-from sqlalchemy import delete
-from sqlalchemy import or_
-from sqlalchemy import select
+from sqlalchemy import delete, or_, select
 from sqlalchemy.orm import selectinload
 
 from db import db

--- a/core/account.py
+++ b/core/account.py
@@ -106,7 +106,7 @@ def put_account(account_id: str) -> Tuple[dict, int]:
     except KeyError:
         return {"error": "roles are required"}, 401
 
-    azure_ad_subject_id = request.json.get("azure_ad_subject_id", None)
+    azure_ad_subject_id = request.json.get("azure_ad_subject_id")
     full_name = request.json.get("full_name")
     email = request.json.get("email_address", "").lower()
 
@@ -116,7 +116,10 @@ def put_account(account_id: str) -> Tuple[dict, int]:
             db.session.query(Account)
             .filter(
                 Account.id == account_id,
-                Account.azure_ad_subject_id == azure_ad_subject_id,
+                or_(
+                    Account.azure_ad_subject_id == azure_ad_subject_id,
+                    Account.azure_ad_subject_id.is_(None),
+                ),
             )
             .one()
         )

--- a/openapi/api.yml
+++ b/openapi/api.yml
@@ -224,7 +224,6 @@ components:
       type: object
       required:
         - roles
-        - azure_ad_subject_id
       properties:
         full_name:
           type: string

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -49,6 +49,12 @@ test_user_to_update = {
     "account_id": uuid4(),
     "roles": ["COMMENTER"],
 }
+test_user_2_to_update = {
+    "email": "seeded_user_y@example.com",
+    "subject_id": None,
+    "account_id": uuid4(),
+    "roles": ["COMMENTER"],
+}
 
 
 def create_user_with_roles(user_config, db):
@@ -73,7 +79,7 @@ def create_user_with_roles(user_config, db):
 def seed_test_data(request, app, clear_test_data, _db):
     marker = request.node.get_closest_marker("user_config")
     if not marker:
-        users_to_create = [test_user_1, test_user_2, test_user_to_update]
+        users_to_create = [test_user_1, test_user_2, test_user_to_update, test_user_2_to_update]
     else:
         users_to_create = marker.args[0]
     for user in users_to_create:
@@ -85,7 +91,7 @@ def seed_test_data(request, app, clear_test_data, _db):
 def seed_test_data_fn(request, app, clear_test_data, _db):
     marker = request.node.get_closest_marker("user_config")
     if not marker:
-        users_to_create = [test_user_1, test_user_2, test_user_to_update]
+        users_to_create = [test_user_1, test_user_2, test_user_to_update, test_user_2_to_update]
     else:
         users_to_create = marker.args[0]
     for user in users_to_create:

--- a/tests/test_accounts.py
+++ b/tests/test_accounts.py
@@ -6,9 +6,12 @@ import uuid
 
 import pytest
 
-from tests.conftest import test_user_1
-from tests.conftest import test_user_2
-from tests.conftest import test_user_to_update
+from tests.conftest import (
+    test_user_1,
+    test_user_2,
+    test_user_2_to_update,
+    test_user_to_update,
+)
 from tests.helpers import expected_data_within_response
 
 
@@ -247,7 +250,7 @@ class TestAccountsPut:
             json=params,
         )
 
-    def test_update_full_name_role_without_azure_ad_subject_id_fails(
+    def test_update_full_name_role_without_azure_ad_subject_id(
         self, flask_test_client, clear_test_data, seed_test_data
     ):
         """
@@ -258,12 +261,12 @@ class TestAccountsPut:
                 "roles":"LEAD_ASSESSOR",
                 "full_name": "Jane Doe",
             }
-        THEN a bad request error is returned
-
+        THEN it updates user
         """
-        account_id = str(test_user_to_update["account_id"])
+
+        account_id = str(test_user_2_to_update["account_id"])
         new_roles = ["LEAD_ASSESSOR"]
-        new_full_name = "Jane Doe 2"
+        new_full_name = "John Doe"
         params = {
             "roles": new_roles,
             "full_name": new_full_name,
@@ -272,8 +275,10 @@ class TestAccountsPut:
 
         response = flask_test_client.put(url, json=params)
 
-        assert response.status_code == 400
-        assert response.json().get("detail") == "'azure_ad_subject_id' is a required property"
+        assert response.status_code == 201
+
+        assert response.json()["account_id"] == account_id
+        assert response.json()["roles"] == ["LEAD_ASSESSOR"]
 
     def test_update_role_only(self, flask_test_client, clear_test_data, seed_test_data):
         """

--- a/tests/test_accounts.py
+++ b/tests/test_accounts.py
@@ -276,9 +276,39 @@ class TestAccountsPut:
         response = flask_test_client.put(url, json=params)
 
         assert response.status_code == 201
-
         assert response.json()["account_id"] == account_id
         assert response.json()["roles"] == ["LEAD_ASSESSOR"]
+
+    def test_update_user_without_azure_ad_subject_id_to_have_one(
+        self,
+        flask_test_client,
+        clear_test_data,
+        seed_test_data,
+    ):
+        """
+        GIVEN The flask test client
+        WHEN we PUT to the /accounts/{account_id} endpoint
+        WITH a json payload of
+            {
+                "roles":"LEAD_ASSESSOR",
+                "azure_ad_subject_id": "123-123-123",
+            }
+        THEN it updates user
+        """
+
+        account_id = str(test_user_2_to_update["account_id"])
+        new_roles = ["LEAD_ASSESSOR"]
+        params = {
+            "roles": new_roles,
+            "azure_ad_subject_id": "123-123-123",
+        }
+        url = "/accounts/" + account_id
+
+        response = flask_test_client.put(url, json=params)
+
+        assert response.status_code == 201
+        assert response.json()["account_id"] == account_id
+        assert response.json()["azure_ad_subject_id"] == "123-123-123"
 
     def test_update_role_only(self, flask_test_client, clear_test_data, seed_test_data):
         """

--- a/tests/test_accounts.py
+++ b/tests/test_accounts.py
@@ -6,12 +6,10 @@ import uuid
 
 import pytest
 
-from tests.conftest import (
-    test_user_1,
-    test_user_2,
-    test_user_2_to_update,
-    test_user_to_update,
-)
+from tests.conftest import test_user_1
+from tests.conftest import test_user_2
+from tests.conftest import test_user_2_to_update
+from tests.conftest import test_user_to_update
 from tests.helpers import expected_data_within_response
 
 


### PR DESCRIPTION
### Change description
Change `azure_ad_subject_id` to be optional when updating accounts.

We'd like to be able to update the roles of an account generated with a Magic Link.
These accounts don't have an `azure_ad_subject_id` and throw 400's when trying to update.