### PR TITLE
Add accounts search endpoint

### DIFF
--- a/openapi/api.yml
+++ b/openapi/api.yml
@@ -160,7 +160,7 @@ paths:
         content:
           application/json:
             schema:
-              $ref: '#/components/schemas/search'
+              $ref: '#/components/schemas/accountSearch'
       responses:
         200:
           description: One or more account exist and are associated with the fund and round
@@ -231,7 +231,7 @@ components:
               type: object
               description: A map of the highest role for each service
               example: {"COF": "ASSESSOR", "NSTF": "COMMENTER"}
-    search:
+    accountSearch:
       type: object
       nullable: true
       additionalProperties: false

--- a/openapi/api.yml
+++ b/openapi/api.yml
@@ -150,6 +150,26 @@ paths:
                   $ref: '#/components/schemas/account'
         404:
           description: "No associated accounts found."
+  /accounts/search:
+    post:
+      tags:
+        - accounts
+      summary: Search for accounts based on certain criteria
+      operationId: core.account.search_accounts
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/search'
+      responses:
+        200:
+          description: One or more account exist and are associated with the fund and round
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: '#/components/schemas/account'
   /bulk-accounts:
     get:
       tags:
@@ -211,6 +231,29 @@ components:
               type: object
               description: A map of the highest role for each service
               example: {"COF": "ASSESSOR", "NSTF": "COMMENTER"}
+    search:
+      type: object
+      nullable: true
+      additionalProperties: false
+      properties:
+        email_domain:
+          description: "Search by email domain"
+          example: "communities.gov.uk"
+          type: string
+        roles:
+          description: "Filter results to accounts that have ANY of these roles."
+          example: ['SECTION_151', 'COF_ASSESSOR_R1']
+          type: array
+          items:
+            type: string
+        partial_roles:
+          description: "Filter results to accounts that have roles partially matching ANY of these values."
+          example: ['ASSESSOR']
+          type: array
+          items:
+            type: string
+      not:
+        required: [roles, partial_roles]
 
     accountCreate:
       type: object


### PR DESCRIPTION
### Change description
On post-award we need a way to list all accounts with the (new) SECTION_151 role that are under a specific email domain.

This new endpoint provides that core functionality.

https://dluhcdigital.atlassian.net/browse/FPASF-477

- [x] Unit tests and other appropriate tests added or updated
- [x] README and other documentation has been updated / added (if needed)
- [x] Commit messages are meaningful and follow good commit message guidelines (e.g. "FS-XXXX: Add margin to nav items preventing overlapping of logo")


### How to test
* Enable the swagger UI by updating `app.py` to:
    ```
    connexion_app = connexion.FlaskApp(
        __name__,
        specification_dir=Config.FLASK_ROOT + "/openapi/",
        swagger_ui_options=SwaggerUIOptions(swagger_ui_path="/docs"),
    )
    ```
* Run the app and go to http://localhost:3003/docs/#/accounts/core.account.search_accounts
* Use the swagger UI to test the new endpoint.
