### PR TITLE
FPASF-490: Turn warnings into errors when running pytest

### DIFF
--- a/db/migrations/env.py
+++ b/db/migrations/env.py
@@ -21,7 +21,7 @@ logger = logging.getLogger("alembic.env")
 # target_metadata = mymodel.Base.metadata
 config.set_main_option(
     "sqlalchemy.url",
-    str(current_app.extensions["migrate"].db.get_engine().url).replace("%", "%%"),
+    str(current_app.extensions["migrate"].db.engine.url).replace("%", "%%"),
 )
 target_metadata = current_app.extensions["migrate"].db.metadata
 
@@ -68,7 +68,7 @@ def run_migrations_online():
                 directives[:] = []
                 logger.info("No changes in schema detected.")
 
-    connectable = current_app.extensions["migrate"].db.get_engine()
+    connectable = current_app.extensions["migrate"].db.engine
 
     with connectable.connect() as connection:
         context.configure(

--- a/pytest.ini
+++ b/pytest.ini
@@ -5,3 +5,16 @@ env =
     # pragma: allowlist nextline secret
     D:DATABASE_URL=postgresql://postgres:postgres@127.0.0.1:5432/fsd_account_store
     GITHUB_SHA=123123
+
+markers =
+    user_config: used to provide users to tests
+
+filterwarnings =
+    error
+
+    # ignore warnings from connexion
+    ignore::DeprecationWarning:connexion\.json_schema
+    ignore::DeprecationWarning:connexion\.validators
+
+    # ignore warnings from pytest about unraisable exceptions caused during test teardown
+    ignore::pytest.PytestUnraisableExceptionWarning

--- a/pytest.ini
+++ b/pytest.ini
@@ -13,8 +13,6 @@ filterwarnings =
     error
 
     # ignore warnings from connexion
-    ignore::DeprecationWarning:connexion\.json_schema
-    ignore::DeprecationWarning:connexion\.validators
-
-    # ignore warnings from pytest about unraisable exceptions caused during test teardown
-    ignore::pytest.PytestUnraisableExceptionWarning
+    ignore:jsonschema.RefResolver is deprecated:DeprecationWarning:connexion
+    ignore:jsonschema.exceptions.RefResolutionError is deprecated:DeprecationWarning:connexion
+    ignore:Accessing jsonschema.draft4_format_checker is deprecated:DeprecationWarning:connexion

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -19,7 +19,7 @@ def app():
     yield app.app
 
 
-@pytest.fixture(scope="function")
+@pytest.fixture(scope="session")
 def flask_test_client():
     """
     Creates the test client we will be using to test the responses


### PR DESCRIPTION
### Change description
Turns all warnings into errors so that they can be caught early and developers are required to handle them (either by fixing the code or explicitly ignoring the error).

This ignores a few errors from our dependencies, and fixes others, such as:
- changing `get_engine()` to `engine`
- ignoring `connexion` json schema and validation warnings
- changing scope of the pytest connexion flask fixture to `session` instead of `function`  

### How to test
Are there any warnings?