### PR TITLE
Upgrade pre-commit

### DIFF
--- a/requirements-dev.in
+++ b/requirements-dev.in
@@ -2,7 +2,7 @@
 black
 debugpy
 deepdiff
-pre-commit
+pre-commit~=4.0.0
 pytest>=8.3.1
 pytest-env
 pytest-flask

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -158,9 +158,7 @@ flupy==1.2.0
 funding-service-design-utils==5.1.1
     # via -r requirements.txt
 greenlet==3.1.1
-    # via
-    #   -r requirements.txt
-    #   sqlalchemy
+    # via -r requirements.txt
 gunicorn==22.0.0
     # via
     #   -r requirements.txt
@@ -304,7 +302,7 @@ pluggy==1.5.0
     # via pytest
 prance==23.6.21.0
     # via -r requirements.txt
-pre-commit==3.7.1
+pre-commit==4.0.1
     # via -r requirements-dev.in
 psycopg2-binary==2.9.9
     # via -r requirements.txt


### PR DESCRIPTION
### Change description
Bumps our local pre-commit version to be >=4.0. This matches what runs in pre-commit.ci, so is best to keep roughly in sync.

In particular this bump has been prompted by CI failures on the assessment-store, where one of the installed hooks is incompatible with v4 of pre-commit because the `python_venv` "language" has been removed. We don't see this issue locally on that repo because we're still running an older version of pre-commmit.