### PR TITLE
Allow concurrent paketo builds

### DIFF
--- a/.github/workflows/copilot_deploy.yml
+++ b/.github/workflows/copilot_deploy.yml
@@ -60,7 +60,6 @@ jobs:
 
   paketo_build:
     needs: [ setup ]
-    concurrency: build-account-store-pack
     permissions:
       packages: write
     uses: communitiesuk/funding-service-design-workflows/.github/workflows/package.yml@main


### PR DESCRIPTION
### Change description
With concurrency groups enabled, GitHub will start cancelling jobs if more than one is pending. We run paketo build as part of PR checks, so if multiple PRs are opened around the same time (3+), then when the latest PR is opened, it will cancel the Paketo build job of a previous PR that is currently "pending". This leads to a "cancelled check" report on the PR, which is
 a red cross and looks bad. We should be able to build as many images as are needed for the PRs we have up.