### PR TITLE
Turn off recreate deploys in test environment

### DIFF
--- a/copilot/fsd-account-store/manifest.yml
+++ b/copilot/fsd-account-store/manifest.yml
@@ -55,8 +55,6 @@ environments:
     count:
       spot: 1
   test:
-    deployment:
-      rolling: 'recreate'
     count:
       spot: 2
   uat:


### PR DESCRIPTION
### Change description
This is because the `recreate` deployment method leads to downtime, which can cause tests to flake. It is not any faster than a normal deployment, and causes tests to break. I am not sure why it was chosen to begin with.

https://aws.github.io/copilot-cli/docs/manifest/lb-web-service/#deployment-rolling