### PR TITLE
Remove workflow exceptions

### DIFF
--- a/.github/workflows/copilot_deploy.yml
+++ b/.github/workflows/copilot_deploy.yml
@@ -29,22 +29,6 @@ on:
         type: boolean
         description: Run e2e tests (application)
   push:
-    # Ignore README markdown
-    # Only automatically deploy when something in the app or tests folder has changed
-    paths:
-      - '!**/README.md'
-      - 'project.toml'
-      - 'core/**'
-      - 'config/**'
-      - 'db/**'
-      - 'openapi/**'
-      - 'scripts/**'
-      - 'tests/**'
-      - 'requirements-dev.in'
-      - 'requirements-dev.txt'
-      - 'requirements.in'
-      - 'requirements.txt'
-      - '.github/workflows/copilot_deploy.yml'
 
 jobs:
   setup:


### PR DESCRIPTION
These paths control whether or not the workflow runs on push, including to PRs.

Unless these are kept perfectly up-to-date, then sometimes we'll not run tests on PRs that should have them run.

See https://github.com/communitiesuk/funding-service-design-account-store/pull/258 which changes pyproject.toml and uv.lock. This should definitely be tested but isn't. I could add the files, but that just pushes the problem into the future. A few "wasted" runs are better than missing one "required" run, IMO. Let's do the safe thing here.