### PR TITLE
Pass AWS_ACCOUNT through to workflows

### DIFF
--- a/.github/workflows/copilot_deploy.yml
+++ b/.github/workflows/copilot_deploy.yml
@@ -74,6 +74,7 @@ jobs:
       FSD_GH_APP_KEY: ${{ secrets.FSD_GH_APP_KEY }}
       FS_BASIC_AUTH_USERNAME: ${{ secrets.FS_BASIC_AUTH_USERNAME }}
       FS_BASIC_AUTH_PASSWORD: ${{ secrets.FS_BASIC_AUTH_PASSWORD }}
+      AWS_ACCOUNT: ${{ secrets.AWS_ACCOUNT }}
     uses: communitiesuk/funding-service-design-workflows/.github/workflows/post-deploy.yml@main
     with:
       run_performance_tests: ${{ inputs.run_performance_tests || true }}
@@ -105,6 +106,7 @@ jobs:
       FSD_GH_APP_KEY: ${{ secrets.FSD_GH_APP_KEY }}
       FS_BASIC_AUTH_USERNAME: ${{ secrets.FS_BASIC_AUTH_USERNAME }}
       FS_BASIC_AUTH_PASSWORD: ${{ secrets.FS_BASIC_AUTH_PASSWORD }}
+      AWS_ACCOUNT: ${{ secrets.AWS_ACCOUNT }}
     uses: communitiesuk/funding-service-design-workflows/.github/workflows/post-deploy.yml@main
     with:
       run_performance_tests: ${{ inputs.run_performance_tests || false }}
@@ -136,6 +138,7 @@ jobs:
       FSD_GH_APP_KEY: ${{ secrets.FSD_GH_APP_KEY }}
       FS_BASIC_AUTH_USERNAME: ${{ secrets.FS_BASIC_AUTH_USERNAME }}
       FS_BASIC_AUTH_PASSWORD: ${{ secrets.FS_BASIC_AUTH_PASSWORD }}
+      AWS_ACCOUNT: ${{ secrets.AWS_ACCOUNT }}
     uses: communitiesuk/funding-service-design-workflows/.github/workflows/post-deploy.yml@main
     with:
       run_performance_tests: ${{ inputs.run_performance_tests || false }}


### PR DESCRIPTION
Because the e2e tests run in a workflow defined in another repo, we need to pass the secret through explicitly.