### PR TITLE
FSPT-123: Trace all requests on pre-prod

### DIFF
--- a/copilot/fsd-account-store/manifest.yml
+++ b/copilot/fsd-account-store/manifest.yml
@@ -45,6 +45,8 @@ network:
 variables:
   SENTRY_DSN: "https://db2ea0ad22a44f4db6e81fe74d85fa8f@o1432034.ingest.sentry.io/4503903103352832"
   FLASK_ENV: ${COPILOT_ENVIRONMENT_NAME}
+  SENTRY_TRACES_SAMPLE_RATE: 1.0
+
 
 secrets:
   SECRET_KEY: /copilot/${COPILOT_APPLICATION_NAME}/${COPILOT_ENVIRONMENT_NAME}/secrets/SECRET_KEY
@@ -82,3 +84,5 @@ environments:
       requests: 30
     variables:
       FLASK_ENV: production
+      SENTRY_TRACES_SAMPLE_RATE: 0.02
+

--- a/copilot/fsd-account-store/manifest.yml
+++ b/copilot/fsd-account-store/manifest.yml
@@ -85,4 +85,3 @@ environments:
     variables:
       FLASK_ENV: production
       SENTRY_TRACES_SAMPLE_RATE: 0.02
-


### PR DESCRIPTION
### Change description
Trace all requests on pre-prod

The production value is based on utils default from: https://github.com/communitiesuk/funding-service-design-utils/blob/b65c285328847640f8622c368595938b60e44d02/fsd_utils/sentry/init_sentry.py#L19C59-L19C63 we could possibly increase this in future, but previously a combination of bot traffic and looping errors have used all our quota.

- [ ] Unit tests and other appropriate tests added or updated
- [ ] README and other documentation has been updated / added (if needed)
- [x] Commit messages are meaningful and follow good commit message guidelines (e.g. "FS-XXXX: Add margin to nav items preventing overlapping of logo")


### How to test
Traces should increase post-deployment


### Screenshots of UI changes (if applicable)
